### PR TITLE
Create core domain repositories

### DIFF
--- a/repository_creation_summary.md
+++ b/repository_creation_summary.md
@@ -1,0 +1,74 @@
+# ECommerce Repository Interfaces and Implementations Creation Summary
+
+## Overview
+Successfully created repository interfaces and implementations for all entities in ECommerce.Domain.Entities (excluding Auth entities as requested).
+
+## Created Repository Interfaces
+Location: `src/ECommerce.Application/Interfaces/`
+
+1. **ICartRepository.cs** - Repository interface for Cart entity
+2. **ICartItemRepository.cs** - Repository interface for CartItem entity  
+3. **ICategoryRepository.cs** - Repository interface for Category entity
+4. **ICouponRepository.cs** - Repository interface for Coupon entity
+5. **IOrderRepository.cs** - Repository interface for Order entity
+6. **IOrderItemRepository.cs** - Repository interface for OrderItem entity
+7. **IPaymentRepository.cs** - Repository interface for Payment entity
+8. **IProductRepository.cs** - Repository interface for Product entity
+9. **IReviewRepository.cs** - Repository interface for Review entity
+10. **IShippingAddressRepository.cs** - Repository interface for ShippingAddress entity
+11. **IWishListRepository.cs** - Repository interface for WishList entity
+
+## Created Repository Implementations
+Location: `src/ECommerce.Infrastructure/Persistence/Repositories/`
+
+1. **CartRepository.cs** - Repository implementation for Cart entity
+2. **CartItemRepository.cs** - Repository implementation for CartItem entity
+3. **CategoryRepository.cs** - Repository implementation for Category entity
+4. **CouponRepository.cs** - Repository implementation for Coupon entity
+5. **OrderRepository.cs** - Repository implementation for Order entity
+6. **OrderItemRepository.cs** - Repository implementation for OrderItem entity
+7. **PaymentRepository.cs** - Repository implementation for Payment entity
+8. **ProductRepository.cs** - Repository implementation for Product entity
+9. **ReviewRepository.cs** - Repository implementation for Review entity
+10. **ShippingAddressRepository.cs** - Repository implementation for ShippingAddress entity
+11. **WishListRepository.cs** - Repository implementation for WishList entity
+
+## Pattern Used
+
+### Interface Pattern
+```csharp
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface I{EntityName}Repository : IRepository<{EntityName}>
+{
+}
+```
+
+### Implementation Pattern
+```csharp
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class {EntityName}Repository(ECommerceDbContext context) : Repository<{EntityName}>(context), I{EntityName}Repository
+{
+}
+```
+
+## Excluded Entities
+The following entities from ECommerce.Domain.Entities.Auth were excluded as requested:
+- User
+- Role  
+- Permission
+- RolePermission
+- UserRole
+
+## Notes
+- All repositories inherit from the base `IRepository<T>` interface and `Repository<T>` implementation
+- All repositories use primary constructor syntax (C# 12 feature)
+- All repositories follow the existing project patterns and naming conventions
+- The repositories are ready for dependency injection registration

--- a/src/ECommerce.Application/Interfaces/ICartItemRepository.cs
+++ b/src/ECommerce.Application/Interfaces/ICartItemRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface ICartItemRepository : IRepository<CartItem>
+{
+}

--- a/src/ECommerce.Application/Interfaces/ICartRepository.cs
+++ b/src/ECommerce.Application/Interfaces/ICartRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface ICartRepository : IRepository<Cart>
+{
+}

--- a/src/ECommerce.Application/Interfaces/ICategoryRepository.cs
+++ b/src/ECommerce.Application/Interfaces/ICategoryRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface ICategoryRepository : IRepository<Category>
+{
+}

--- a/src/ECommerce.Application/Interfaces/ICouponRepository.cs
+++ b/src/ECommerce.Application/Interfaces/ICouponRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface ICouponRepository : IRepository<Coupon>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IOrderItemRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IOrderItemRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IOrderItemRepository : IRepository<OrderItem>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IOrderRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IOrderRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IOrderRepository : IRepository<Order>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IPaymentRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IPaymentRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IPaymentRepository : IRepository<Payment>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IProductRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IProductRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IProductRepository : IRepository<Product>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IReviewRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IReviewRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IReviewRepository : IRepository<Review>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IShippingAddressRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IShippingAddressRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IShippingAddressRepository : IRepository<ShippingAddress>
+{
+}

--- a/src/ECommerce.Application/Interfaces/IWishListRepository.cs
+++ b/src/ECommerce.Application/Interfaces/IWishListRepository.cs
@@ -1,0 +1,7 @@
+using ECommerce.Domain.Entities;
+
+namespace ECommerce.Application.Interfaces;
+
+public interface IWishListRepository : IRepository<WishList>
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/CartItemRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/CartItemRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class CartItemRepository(ECommerceDbContext context) : Repository<CartItem>(context), ICartItemRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/CartRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/CartRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class CartRepository(ECommerceDbContext context) : Repository<Cart>(context), ICartRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/CategoryRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/CategoryRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class CategoryRepository(ECommerceDbContext context) : Repository<Category>(context), ICategoryRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/CouponRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/CouponRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class CouponRepository(ECommerceDbContext context) : Repository<Coupon>(context), ICouponRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/OrderItemRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/OrderItemRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class OrderItemRepository(ECommerceDbContext context) : Repository<OrderItem>(context), IOrderItemRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/OrderRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/OrderRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class OrderRepository(ECommerceDbContext context) : Repository<Order>(context), IOrderRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/PaymentRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/PaymentRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class PaymentRepository(ECommerceDbContext context) : Repository<Payment>(context), IPaymentRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/ProductRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/ProductRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class ProductRepository(ECommerceDbContext context) : Repository<Product>(context), IProductRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/ReviewRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/ReviewRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class ReviewRepository(ECommerceDbContext context) : Repository<Review>(context), IReviewRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/ShippingAddressRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/ShippingAddressRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class ShippingAddressRepository(ECommerceDbContext context) : Repository<ShippingAddress>(context), IShippingAddressRepository
+{
+}

--- a/src/ECommerce.Infrastructure/Persistence/Repositories/WishListRepository.cs
+++ b/src/ECommerce.Infrastructure/Persistence/Repositories/WishListRepository.cs
@@ -1,0 +1,9 @@
+using ECommerce.Application.Interfaces;
+using ECommerce.Domain.Entities;
+using ECommerce.Infrastructure.Persistence.Database;
+
+namespace ECommerce.Infrastructure.Persistence.Repositories;
+
+public class WishListRepository(ECommerceDbContext context) : Repository<WishList>(context), IWishListRepository
+{
+}


### PR DESCRIPTION
Add repository interfaces and implementations for ECommerce domain entities, excluding Auth-related ones.

This PR introduces a set of new repository interfaces in `ECommerce.Application.Interfaces` and their corresponding implementations in `ECommerce.Infrastructure.Persistence.Repositories`. As per the task, all entities from `ECommerce.Domain.Entities.Auth` (User, Role, etc.) have been explicitly excluded from this set of repositories to focus on core ECommerce domain data access.